### PR TITLE
Add proper color for articles in dark mode

### DIFF
--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -73,7 +73,7 @@ const imageUrl: string = `https://www.juststeveking.uk${image}`;
         </figure>
 
         <article
-          class="prose lg:prose-xl max-w-7xl px-6 prose-code:py-4 prose-code:px-1 prose-a:text-slate-700 dark:prose-a:text-slate-200 prose-pre:text-black dark:prose-pre:text-white"
+          class="prose lg:prose-xl max-w-7xl px-6 prose-code:py-4 prose-code:px-1 prose-a:text-slate-700 dark:prose-a:text-slate-200 prose-pre:text-black dark:prose-pre:text-white dark:prose-p:text-white dark:prose-h2:text-white dark:prose-h3:text-white dark:prose-code:text-white"
           itemprop="articleBody"
         >
           <Content />


### PR DESCRIPTION
### Before

<img width="1676" alt="CleanShot 2024-01-22 at 17 46 20@2x" src="https://github.com/JustSteveKing/website/assets/171715/1ce3c7d6-1dee-435c-8c1e-ef565309a845">

### After

<img width="1675" alt="CleanShot 2024-01-22 at 17 46 37@2x" src="https://github.com/JustSteveKing/website/assets/171715/7c6caa51-397f-4ac5-861a-cf98cdc20c88">
